### PR TITLE
fix: Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pyinstaller --noconfirm --onefile --windowed --name "Soundboard" --add-data "config.json;." "soundboard.py"
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Soundboard-Windows
         path: dist/Soundboard.exe
@@ -48,7 +48,7 @@ jobs:
       run: |
         hdiutil create ./Soundboard.dmg -srcfolder dist/Soundboard.app -ov
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Soundboard-macOS
         path: Soundboard.dmg


### PR DESCRIPTION
The previous commit used a deprecated version of `actions/upload-artifact`, which caused the workflow to fail.

This commit updates the `actions/upload-artifact` action from `v3` to `v4` to fix the build.