### PR TITLE
feat: Add multi-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,11 @@ name: Build Soundboard Application
 
 on:
   push:
-    branches: [ main ]
-  workflow_dispatch:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-windows:
@@ -28,27 +31,89 @@ jobs:
         name: Soundboard-Windows
         path: dist/Soundboard.exe
 
-  build-macos:
-    runs-on: macos-latest
+  build-macos-x86_64:
+    runs-on: macos-15
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pyinstaller
-    - name: Build with PyInstaller
-      run: |
-        pyinstaller --noconfirm --windowed --name "Soundboard" --add-data "config.json:." "soundboard.py"
-    - name: Create App Bundle
-      run: |
-        hdiutil create ./Soundboard.dmg -srcfolder dist/Soundboard.app -ov
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: Soundboard-macOS
-        path: Soundboard.dmg
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rosetta 2
+        run: |
+          # Install Rosetta 2 if it's not already installed on the runner
+          if ! pgrep -q oahd; then
+            sudo softwareupdate --install-rosetta --agree-to-license
+          fi
+
+      - name: Set up x86_64 Homebrew and Python
+        run: |
+          # Install x86_64 Homebrew to /usr/local
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+          # Use x86_64 Homebrew to install x86_64 Python
+          arch -x86_64 /usr/local/bin/brew install python@3.11
+
+          # Update the PATH to ensure we use the correct x86_64 Python
+          echo "PATH=/usr/local/opt/python@3.11/bin:$PATH" >> $GITHUB_ENV
+
+          # Install FFmpeg for pydub to use
+          arch -x86_64 /usr/local/bin/brew install ffmpeg
+
+      - name: Install dependencies (x86_64)
+        run: |
+          # Use the x86_64 pip to install dependencies
+          arch -x86_64 /usr/local/opt/python@3.11/bin/python3 -m pip install --upgrade pip
+          arch -x86_64 /usr/local/opt/python@3.11/bin/pip3 install -r requirements.txt
+          arch -x86_64 /usr/local/opt/python@3.11/bin/pip3 install pyinstaller
+
+      - name: Build with PyInstaller (x86_64)
+        env:
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
+        run: |
+          # Use the x86_64 pyinstaller
+          arch -x86_64 /usr/local/opt/python@3.11/bin/pyinstaller --noconfirm --windowed --name "Soundboard" --add-data "config.json:." "soundboard.py" --target-arch x86_64
+
+      - name: Create DMG file
+        run: |
+          hdiutil create ./Soundboard-x86_64.dmg -srcfolder dist/Soundboard.app -ov
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Soundboard-macOS-x86_64
+          path: Soundboard-x86_64.dmg
+
+  build-macos-arm64:
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.11'
+
+      - name: Install FFmpeg
+        run: brew install ffmpeg
+
+      - name: Install dependencies (arm64)
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r requirements.txt
+          pip3 install pyinstaller
+
+      - name: Build with PyInstaller (arm64)
+        env:
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
+        run: |
+          pyinstaller --noconfirm --windowed --name "Soundboard" --add-data "config.json:." "soundboard.py" --target-arch arm64
+
+      - name: Create DMG file
+        run: |
+          hdiutil create ./Soundboard-arm64.dmg -srcfolder dist/Soundboard.app -ov
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Soundboard-macOS-arm64
+          path: Soundboard-arm64.dmg


### PR DESCRIPTION
This commit implements a GitHub Actions workflow to build the application for Windows, macOS (Intel), and macOS (Apple Silicon).

The workflow includes three jobs:
- `build-windows`: Creates a single-file .exe for Windows.
- `build-macos-x86_64`: Creates a .dmg for Intel-based Macs by building in a Rosetta 2 environment on an ARM64 runner.
- `build-macos-arm64`: Creates a .dmg for Apple Silicon-based Macs using the native ARM64 environment.

This addresses all build requirements, including the need for `ffmpeg` for the `pydub` dependency on macOS. The `config` file was also renamed to `config.json` to be compatible with the build script.