### PR TITLE
fix(macos): Resolve Homebrew symlink conflict in x86_64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,10 @@ jobs:
         run: |
           # Install x86_64 Homebrew to /usr/local
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
           # Use x86_64 Homebrew to install x86_64 Python
           arch -x86_64 /usr/local/bin/brew install python@3.11
-
+          # Force link to overwrite any conflicting symlinks
+          arch -x86_64 /usr/local/bin/brew link --overwrite python@3.11
           # Update the PATH to ensure we use the correct x86_64 Python
           echo "PATH=/usr/local/opt/python@3.11/bin:$PATH" >> $GITHUB_ENV
 


### PR DESCRIPTION
The `build-macos-x86_64` job was failing because the Homebrew installation of `python@3.11` could not create symlinks in `/usr/local/bin` due to pre-existing files on the runner.

This commit resolves the issue by adding a `brew link --overwrite python@3.11` command to the setup step. This forcefully creates the necessary symlinks, ensuring the correct x86_64 version of Python is used for the build.