### PR TITLE
fix(macos): Refactor x86_64 build to use default Homebrew python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,38 +39,27 @@ jobs:
 
       - name: Install Rosetta 2
         run: |
-          # Install Rosetta 2 if it's not already installed on the runner
           if ! pgrep -q oahd; then
             sudo softwareupdate --install-rosetta --agree-to-license
           fi
 
-      - name: Set up x86_64 Homebrew and Python
+      - name: Set up x86_64 environment
         run: |
-          # Install x86_64 Homebrew to /usr/local
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          # Use x86_64 Homebrew to install x86_64 Python
-          arch -x86_64 /usr/local/bin/brew install python@3.11
-          # Force link to overwrite any conflicting symlinks
-          arch -x86_64 /usr/local/bin/brew link --overwrite python@3.11
-          # Update the PATH to ensure we use the correct x86_64 Python
-          echo "PATH=/usr/local/opt/python@3.11/bin:$PATH" >> $GITHUB_ENV
+          arch -x86_64 /usr/local/bin/brew install python3 ffmpeg
+          echo "PATH=$(arch -x86_64 /usr/local/bin/brew --prefix)/bin:$PATH" >> $GITHUB_ENV
 
-          # Install FFmpeg for pydub to use
-          arch -x86_64 /usr/local/bin/brew install ffmpeg
-
-      - name: Install dependencies (x86_64)
+      - name: Install Python dependencies (x86_64)
         run: |
-          # Use the x86_64 pip to install dependencies
-          arch -x86_64 /usr/local/opt/python@3.11/bin/python3 -m pip install --upgrade pip
-          arch -x86_64 /usr/local/opt/python@3.11/bin/pip3 install -r requirements.txt
-          arch -x86_64 /usr/local/opt/python@3.11/bin/pip3 install pyinstaller
+          arch -x86_64 python3 -m pip install --upgrade pip
+          arch -x86_64 pip3 install -r requirements.txt
+          arch -x86_64 pip3 install pyinstaller
 
       - name: Build with PyInstaller (x86_64)
         env:
           MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
-          # Use the x86_64 pyinstaller
-          arch -x86_64 /usr/local/opt/python@3.11/bin/pyinstaller --noconfirm --windowed --name "Soundboard" --add-data "config.json:." "soundboard.py" --target-arch x86_64
+          arch -x86_64 pyinstaller --noconfirm --windowed --name "Soundboard" --add-data "config.json:." "soundboard.py" --target-arch x86_64
 
       - name: Create DMG file
         run: |


### PR DESCRIPTION
The `build-macos-x86_64` job was failing due to Homebrew symlink conflicts when trying to install a specific version of Python (`python@3.11`).

This commit refactors the job to use the recommended approach of installing the default `python3` formula from Homebrew and then adding the Homebrew bin directory to the `PATH`. This avoids the symlink issues and creates a more robust build environment.